### PR TITLE
Output range and offset for POLYLFO, improvements to reset behaviour and overall amplitude for ENVGEN

### DIFF
--- a/software/o_c_REV/APP_ENVGEN.ino
+++ b/software/o_c_REV/APP_ENVGEN.ino
@@ -68,6 +68,7 @@ enum EnvelopeSettings {
   ENV_SETTING_ATTACK_TIME_MULTIPLIER,
   ENV_SETTING_DECAY_TIME_MULTIPLIER,
   ENV_SETTING_RELEASE_TIME_MULTIPLIER,
+  ENV_SETTING_LEVEL,
   ENV_SETTING_LAST
 };
 
@@ -81,6 +82,8 @@ enum CVMapping {
   CV_MAPPING_EUCLIDEAN_FILL,
   CV_MAPPING_EUCLIDEAN_OFFSET,
   CV_MAPPING_DELAY_MSEC,
+  CV_MAPPING_LEVEL_CONT,
+  CV_MAPPING_LEVEL_SH,
   CV_MAPPING_LAST
 };
 
@@ -161,6 +164,10 @@ public:
 
   uint8_t get_euclidean_offset() const {
     return values_[ENV_SETTING_EUCLIDEAN_OFFSET];
+  }
+
+  uint8_t get_level() const {
+    return values_[ENV_SETTING_LEVEL];
   }
 
   // Debug only
@@ -314,6 +321,7 @@ public:
     *settings++ = ENV_SETTING_ATTACK_RESET_BEHAVIOUR;
     *settings++ = ENV_SETTING_DECAY_RELEASE_RESET_BEHAVIOUR;
     *settings++ = ENV_SETTING_GATE_HIGH;
+    *settings++ = ENV_SETTING_LEVEL;
 
     num_enabled_settings_ = settings - enabled_settings_;
   }
@@ -547,7 +555,7 @@ const char* const envelope_shapes[peaks::ENV_SHAPE_LAST] = {
 };
 
 const char* const cv_mapping_names[CV_MAPPING_LAST] = {
-  "None", "Att", "Dec", "Sus", "Rel", "Eleng", "Efill", "Eoffs", "Delay"
+  "None", "Att", "Dec", "Sus", "Rel", "Eleng", "Efill", "Eoffs", "Delay", "Level", "LvlSH"
 };
 
 const char* const trigger_delay_modes[TRIGGER_DELAY_LAST] = {
@@ -596,6 +604,7 @@ SETTINGS_DECLARE(EnvelopeGenerator, ENV_SETTING_LAST) {
   { 0, 0, 13, "Attack mult", time_multipliers, settings::STORAGE_TYPE_U4 },
   { 0, 0, 13, "Decay mult", time_multipliers, settings::STORAGE_TYPE_U4 },
   {0, 0, 13, "Release mult", time_multipliers, settings::STORAGE_TYPE_U4 },
+  {127, 0, 127, "Amplitude", time_multipliers, settings::STORAGE_TYPE_U8 },
 };
 
 class QuadEnvelopeGenerator {

--- a/software/o_c_REV/APP_ENVGEN.ino
+++ b/software/o_c_REV/APP_ENVGEN.ino
@@ -59,7 +59,7 @@ enum EnvelopeSettings {
   ENV_SETTING_CV2,
   ENV_SETTING_CV3,
   ENV_SETTING_CV4,
-  ENV_SETTING_HARD_RESET,
+  ENV_SETTING_RESET_BEHAVIOUR,
   ENV_SETTING_GATE_HIGH,
   ENV_SETTING_ATTACK_SHAPE,
   ENV_SETTING_DECAY_SHAPE,
@@ -142,6 +142,10 @@ public:
     return static_cast<TriggerDelayMode>(values_[ENV_SETTING_TRIGGER_DELAY_MODE]);
   }
 
+  peaks::EnvResetBehaviour get_reset_behaviour() const {
+    return static_cast<peaks::EnvResetBehaviour>(values_[ENV_SETTING_RESET_BEHAVIOUR]);
+  }
+
   uint8_t get_euclidean_length() const {
     return values_[ENV_SETTING_EUCLIDEAN_LENGTH];
   }
@@ -187,9 +191,9 @@ public:
     return static_cast<CVMapping>(values_[ENV_SETTING_CV4]);
   }
 
-  bool get_hard_reset() const {
-    return values_[ENV_SETTING_HARD_RESET];
-  }
+//  bool get_hard_reset() const {
+//    return values_[ENV_SETTING_HARD_RESET];
+//  }
 
   bool get_gate_high() const {
     return values_[ENV_SETTING_GATE_HIGH];
@@ -302,7 +306,7 @@ public:
     *settings++ = ENV_SETTING_CV2;
     *settings++ = ENV_SETTING_CV3;
     *settings++ = ENV_SETTING_CV4;
-    *settings++ = ENV_SETTING_HARD_RESET;
+    *settings++ = ENV_SETTING_RESET_BEHAVIOUR;
     *settings++ = ENV_SETTING_GATE_HIGH;
 
     num_enabled_settings_ = settings - enabled_settings_;
@@ -374,8 +378,8 @@ public:
       env_.reset();
     }
 
-    // hard reset forces the envelope to start at level_[0] on rising gate.
-    env_.set_hard_reset(get_hard_reset());
+    // set the specified reset behaviour
+    env_.set_reset_behaviour(get_reset_behaviour());
 
     // set the envelope segment shapes
     env_.set_attack_shape(get_attack_shape());
@@ -543,6 +547,10 @@ const char* const trigger_delay_modes[TRIGGER_DELAY_LAST] = {
   "Off", "Queue", "Ring"
 };
 
+const char* const reset_behaviours[peaks::RESET_BEHAVIOUR_LAST] = {
+  "Levl", "Phase", "Segmt", "L&P", "Cont"
+};
+
 const char* const euclidean_lengths[] = {
   "Off", "  2", "  3", "  4", "  5", "  6", "  7", "  8", "  9", " 10",
   " 11", " 12", " 13", " 14", " 15", " 16", " 17", " 18", " 19", " 20",
@@ -572,7 +580,7 @@ SETTINGS_DECLARE(EnvelopeGenerator, ENV_SETTING_LAST) {
   { CV_MAPPING_NONE, CV_MAPPING_NONE, CV_MAPPING_LAST - 1, "CV2 -> ", cv_mapping_names, settings::STORAGE_TYPE_U4 },
   { CV_MAPPING_NONE, CV_MAPPING_NONE, CV_MAPPING_LAST - 1, "CV3 -> ", cv_mapping_names, settings::STORAGE_TYPE_U4 },
   { CV_MAPPING_NONE, CV_MAPPING_NONE, CV_MAPPING_LAST - 1, "CV4 -> ", cv_mapping_names, settings::STORAGE_TYPE_U4 },
-  { 0, 0, 1, "Hard reset", OC::Strings::no_yes, settings::STORAGE_TYPE_U4 },
+  { peaks::RESET_BEHAVIOUR_CARRY_ON, peaks::RESET_BEHAVIOUR_LEVEL, peaks::RESET_BEHAVIOUR_LAST - 1, "Reset behav", reset_behaviours, settings::STORAGE_TYPE_U4 },
   { 0, 0, 1, "Gate high", OC::Strings::no_yes, settings::STORAGE_TYPE_U4 },
   { peaks::ENV_SHAPE_QUARTIC, peaks::ENV_SHAPE_LINEAR, peaks::ENV_SHAPE_LAST - 1, "Attack shape", envelope_shapes, settings::STORAGE_TYPE_U4 },
   { peaks::ENV_SHAPE_EXPONENTIAL, peaks::ENV_SHAPE_LINEAR, peaks::ENV_SHAPE_LAST - 1, "Decay shape", envelope_shapes, settings::STORAGE_TYPE_U4 },

--- a/software/o_c_REV/APP_ENVGEN.ino
+++ b/software/o_c_REV/APP_ENVGEN.ino
@@ -68,7 +68,8 @@ enum EnvelopeSettings {
   ENV_SETTING_ATTACK_TIME_MULTIPLIER,
   ENV_SETTING_DECAY_TIME_MULTIPLIER,
   ENV_SETTING_RELEASE_TIME_MULTIPLIER,
-  ENV_SETTING_LEVEL,
+  ENV_SETTING_AMPLITUDE,
+  ENV_SETTING_SAMPLED_AMPLITUDE,
   ENV_SETTING_LAST
 };
 
@@ -82,8 +83,7 @@ enum CVMapping {
   CV_MAPPING_EUCLIDEAN_FILL,
   CV_MAPPING_EUCLIDEAN_OFFSET,
   CV_MAPPING_DELAY_MSEC,
-  CV_MAPPING_LEVEL_CONT,
-  CV_MAPPING_LEVEL_SH,
+  CV_MAPPING_AMPLITUDE,
   CV_MAPPING_LAST
 };
 
@@ -113,6 +113,7 @@ public:
   static constexpr int kMaxSegments = 4;
   static constexpr int kEuclideanParams = 3;
   static constexpr int kDelayParams = 1;
+  static constexpr int kAmplitudeParams = 1;
   static constexpr size_t kMaxDelayedTriggers = 32;
 
   struct DelayedTrigger {
@@ -166,8 +167,12 @@ public:
     return values_[ENV_SETTING_EUCLIDEAN_OFFSET];
   }
 
-  uint8_t get_level() const {
-    return values_[ENV_SETTING_LEVEL];
+  uint16_t get_amplitude() const {
+    return values_[ENV_SETTING_AMPLITUDE] << 9 ;
+  }
+
+  bool is_amplitude_sampled() const {
+     return static_cast<bool>(values_[ENV_SETTING_SAMPLED_AMPLITUDE]);
   }
 
   // Debug only
@@ -258,7 +263,7 @@ public:
     return 0;
   }
 
-  inline void apply_cv_mapping(EnvelopeSettings cv_setting, const int32_t cvs[ADC_CHANNEL_LAST], int32_t segments[kMaxSegments + kEuclideanParams + kDelayParams]) {
+  inline void apply_cv_mapping(EnvelopeSettings cv_setting, const int32_t cvs[ADC_CHANNEL_LAST], int32_t segments[kMaxSegments + kEuclideanParams + kDelayParams + kAmplitudeParams]) {
     int mapping = values_[cv_setting];
     switch (mapping) {
       case CV_MAPPING_SEG1:
@@ -274,6 +279,9 @@ public:
         break;
       case CV_MAPPING_DELAY_MSEC:
         segments[mapping - CV_MAPPING_SEG1] += cvs[cv_setting - ENV_SETTING_CV1]  >> 2;
+        break;
+      case  CV_MAPPING_AMPLITUDE:
+        segments[mapping - CV_MAPPING_SEG1] += cvs[cv_setting - ENV_SETTING_CV1] << 5 ;
         break;
        default:
         break;
@@ -321,7 +329,8 @@ public:
     *settings++ = ENV_SETTING_ATTACK_RESET_BEHAVIOUR;
     *settings++ = ENV_SETTING_DECAY_RELEASE_RESET_BEHAVIOUR;
     *settings++ = ENV_SETTING_GATE_HIGH;
-    *settings++ = ENV_SETTING_LEVEL;
+    *settings++ = ENV_SETTING_AMPLITUDE;
+    *settings++ = ENV_SETTING_SAMPLED_AMPLITUDE;
 
     num_enabled_settings_ = settings - enabled_settings_;
   }
@@ -343,7 +352,7 @@ public:
   template <DAC_CHANNEL dac_channel>
   void Update(uint32_t triggers, const int32_t cvs[ADC_CHANNEL_LAST]) {
 
-    int32_t s[kMaxSegments + kEuclideanParams + kDelayParams];
+    int32_t s[kMaxSegments + kEuclideanParams + kDelayParams + kAmplitudeParams];
     s[0] = SCALE8_16(static_cast<int32_t>(get_segment_value(0)));
     s[1] = SCALE8_16(static_cast<int32_t>(get_segment_value(1)));
     s[2] = SCALE8_16(static_cast<int32_t>(get_segment_value(2)));
@@ -352,6 +361,7 @@ public:
     s[5] = static_cast<int32_t>(get_euclidean_fill());
     s[6] = static_cast<int32_t>(get_euclidean_offset());
     s[7] = get_trigger_delay_ms();
+    s[8] = get_amplitude();
 
     apply_cv_mapping(ENV_SETTING_CV1, cvs, s);
     apply_cv_mapping(ENV_SETTING_CV2, cvs, s);
@@ -366,6 +376,7 @@ public:
     CONSTRAIN(s[5], 0, 32);
     CONSTRAIN(s[6], 0, 32);
     CONSTRAIN(s[7], 0, 65535);
+    CONSTRAIN(s[8], 0, 65535);
 
     // debug only
     // s_euclidean_length_ = s[4];
@@ -387,6 +398,9 @@ public:
       break;
     }
 
+    // set the amplitude
+    env_.set_amplitude(s[8], is_amplitude_sampled()) ;
+    
     if (type != last_type_) {
       last_type_ = type;
       env_.reset();
@@ -473,6 +487,18 @@ public:
     trigger = delayed_triggers_[delayed_triggers_next_];
   }
 
+  inline uint16_t get_amplitude_value() {
+    return(env_.get_amplitude_value()) ;
+  }
+
+  inline uint16_t get_sampled_amplitude_value() {
+    return(env_.get_sampled_amplitude_value()) ;
+  }
+
+  inline bool get_is_amplitude_sampled() {
+    return(env_.get_is_amplitude_sampled()) ;
+  }
+
 private:
 
   peaks::MultistageEnvelope env_;
@@ -555,7 +581,7 @@ const char* const envelope_shapes[peaks::ENV_SHAPE_LAST] = {
 };
 
 const char* const cv_mapping_names[CV_MAPPING_LAST] = {
-  "None", "Att", "Dec", "Sus", "Rel", "Eleng", "Efill", "Eoffs", "Delay", "Level", "LvlSH"
+  "None", "Att", "Dec", "Sus", "Rel", "Eleng", "Efill", "Eoffs", "Delay", "Ampl"
 };
 
 const char* const trigger_delay_modes[TRIGGER_DELAY_LAST] = {
@@ -604,7 +630,8 @@ SETTINGS_DECLARE(EnvelopeGenerator, ENV_SETTING_LAST) {
   { 0, 0, 13, "Attack mult", time_multipliers, settings::STORAGE_TYPE_U4 },
   { 0, 0, 13, "Decay mult", time_multipliers, settings::STORAGE_TYPE_U4 },
   {0, 0, 13, "Release mult", time_multipliers, settings::STORAGE_TYPE_U4 },
-  {127, 0, 127, "Amplitude", time_multipliers, settings::STORAGE_TYPE_U8 },
+  {127, 0, 127, "Amplitude", NULL, settings::STORAGE_TYPE_U8 },
+  {0, 0, 1, "Sampled Ampl", OC::Strings::no_yes, settings::STORAGE_TYPE_U4 },
 };
 
 class QuadEnvelopeGenerator {
@@ -952,17 +979,17 @@ void ENVGEN_screensaver() {
 #endif
 }
 
-//void ENVGEN_debug() {
-//  for (int i = 0; i < 4; ++i) { 
-//    uint8_t ypos = 10*(i + 1) + 2 ; 
-//    graphics.setPrintPos(2, ypos);
-//    graphics.print(envgen.envelopes_[i].get_s_euclidean_length()) ;
-//    graphics.setPrintPos(50, ypos);
-//    graphics.print(envgen.envelopes_[i].get_s_euclidean_fill()) ;
-//    graphics.setPrintPos(100, ypos);
-//    graphics.print(envgen.envelopes_[i].get_s_euclidean_offset()) ;
-//  }
-//}
+void ENVGEN_debug() {
+  for (int i = 0; i < 4; ++i) { 
+    uint8_t ypos = 10*(i + 1) + 2 ; 
+    graphics.setPrintPos(2, ypos);
+    graphics.print(envgen.envelopes_[i].get_amplitude_value()) ;
+    graphics.setPrintPos(50, ypos);
+    graphics.print(envgen.envelopes_[i].get_sampled_amplitude_value()) ;
+    graphics.setPrintPos(100, ypos);
+    graphics.print(envgen.envelopes_[i].get_is_amplitude_sampled()) ;
+  }
+}
 
 void FASTRUN ENVGEN_isr() {
   envgen.ISR();

--- a/software/o_c_REV/APP_ENVGEN.ino
+++ b/software/o_c_REV/APP_ENVGEN.ino
@@ -59,7 +59,8 @@ enum EnvelopeSettings {
   ENV_SETTING_CV2,
   ENV_SETTING_CV3,
   ENV_SETTING_CV4,
-  ENV_SETTING_RESET_BEHAVIOUR,
+  ENV_SETTING_ATTACK_RESET_BEHAVIOUR,
+  ENV_SETTING_DECAY_RELEASE_RESET_BEHAVIOUR,
   ENV_SETTING_GATE_HIGH,
   ENV_SETTING_ATTACK_SHAPE,
   ENV_SETTING_DECAY_SHAPE,
@@ -142,8 +143,12 @@ public:
     return static_cast<TriggerDelayMode>(values_[ENV_SETTING_TRIGGER_DELAY_MODE]);
   }
 
-  peaks::EnvResetBehaviour get_reset_behaviour() const {
-    return static_cast<peaks::EnvResetBehaviour>(values_[ENV_SETTING_RESET_BEHAVIOUR]);
+  peaks::EnvResetBehaviour get_attack_reset_behaviour() const {
+    return static_cast<peaks::EnvResetBehaviour>(values_[ENV_SETTING_ATTACK_RESET_BEHAVIOUR]);
+  }
+
+  peaks::EnvResetBehaviour get_decay_release_reset_behaviour() const {
+    return static_cast<peaks::EnvResetBehaviour>(values_[ENV_SETTING_DECAY_RELEASE_RESET_BEHAVIOUR]);
   }
 
   uint8_t get_euclidean_length() const {
@@ -306,7 +311,8 @@ public:
     *settings++ = ENV_SETTING_CV2;
     *settings++ = ENV_SETTING_CV3;
     *settings++ = ENV_SETTING_CV4;
-    *settings++ = ENV_SETTING_RESET_BEHAVIOUR;
+    *settings++ = ENV_SETTING_ATTACK_RESET_BEHAVIOUR;
+    *settings++ = ENV_SETTING_DECAY_RELEASE_RESET_BEHAVIOUR;
     *settings++ = ENV_SETTING_GATE_HIGH;
 
     num_enabled_settings_ = settings - enabled_settings_;
@@ -379,7 +385,8 @@ public:
     }
 
     // set the specified reset behaviour
-    env_.set_reset_behaviour(get_reset_behaviour());
+    env_.set_attack_reset_behaviour(get_attack_reset_behaviour());
+    env_.set_decay_release_reset_behaviour(get_decay_release_reset_behaviour());
 
     // set the envelope segment shapes
     env_.set_attack_shape(get_attack_shape());
@@ -548,7 +555,7 @@ const char* const trigger_delay_modes[TRIGGER_DELAY_LAST] = {
 };
 
 const char* const reset_behaviours[peaks::RESET_BEHAVIOUR_LAST] = {
-  "Levl", "Phase", "Segmt", "L&P", "Cont"
+  "None",  "SP", "SLP", "SL", "P", 
 };
 
 const char* const euclidean_lengths[] = {
@@ -580,7 +587,8 @@ SETTINGS_DECLARE(EnvelopeGenerator, ENV_SETTING_LAST) {
   { CV_MAPPING_NONE, CV_MAPPING_NONE, CV_MAPPING_LAST - 1, "CV2 -> ", cv_mapping_names, settings::STORAGE_TYPE_U4 },
   { CV_MAPPING_NONE, CV_MAPPING_NONE, CV_MAPPING_LAST - 1, "CV3 -> ", cv_mapping_names, settings::STORAGE_TYPE_U4 },
   { CV_MAPPING_NONE, CV_MAPPING_NONE, CV_MAPPING_LAST - 1, "CV4 -> ", cv_mapping_names, settings::STORAGE_TYPE_U4 },
-  { peaks::RESET_BEHAVIOUR_CARRY_ON, peaks::RESET_BEHAVIOUR_LEVEL, peaks::RESET_BEHAVIOUR_LAST - 1, "Reset behav", reset_behaviours, settings::STORAGE_TYPE_U4 },
+  { peaks::RESET_BEHAVIOUR_NULL, peaks::RESET_BEHAVIOUR_NULL, peaks::RESET_BEHAVIOUR_LAST - 1, "Attack reset", reset_behaviours, settings::STORAGE_TYPE_U4 },
+  { peaks::RESET_BEHAVIOUR_SEGMENT_PHASE, peaks::RESET_BEHAVIOUR_NULL, peaks::RESET_BEHAVIOUR_LAST - 1, "DecRel reset", reset_behaviours, settings::STORAGE_TYPE_U4 },
   { 0, 0, 1, "Gate high", OC::Strings::no_yes, settings::STORAGE_TYPE_U4 },
   { peaks::ENV_SHAPE_QUARTIC, peaks::ENV_SHAPE_LINEAR, peaks::ENV_SHAPE_LAST - 1, "Attack shape", envelope_shapes, settings::STORAGE_TYPE_U4 },
   { peaks::ENV_SHAPE_EXPONENTIAL, peaks::ENV_SHAPE_LINEAR, peaks::ENV_SHAPE_LAST - 1, "Decay shape", envelope_shapes, settings::STORAGE_TYPE_U4 },

--- a/software/o_c_REV/APP_POLYLFO.ino
+++ b/software/o_c_REV/APP_POLYLFO.ino
@@ -165,7 +165,7 @@ SETTINGS_DECLARE(PolyLfo, POLYLFO_SETTING_LAST) {
   { 0, -128, 127, "Shape spread", NULL, settings::STORAGE_TYPE_I8 },
   { -1, -128, 127, "Phase/frq sprd", NULL, settings::STORAGE_TYPE_I8 },
   { 0, -128, 127, "Coupling", NULL, settings::STORAGE_TYPE_I8 },
-  { 230, 0, 230, "Attenuation", NULL, settings::STORAGE_TYPE_U8 },
+  { 230, 0, 230, "Output range", NULL, settings::STORAGE_TYPE_U8 },
   { 0, -128, 127, "Offset", NULL, settings::STORAGE_TYPE_I8 },
   { 9, 0, 11, "Freq range", freq_range_names, settings::STORAGE_TYPE_U4 },
   { frames::POLYLFO_FREQ_DIV_NONE, frames::POLYLFO_FREQ_DIV_NONE, frames::POLYLFO_FREQ_DIV_LAST - 1, "B freq ratio", freq_div_names, settings::STORAGE_TYPE_U8 },

--- a/software/o_c_REV/APP_POLYLFO.ino
+++ b/software/o_c_REV/APP_POLYLFO.ino
@@ -39,6 +39,8 @@ enum POLYLFO_SETTINGS {
   POLYLFO_SETTING_SHAPE_SPREAD,
   POLYLFO_SETTING_SPREAD,
   POLYLFO_SETTING_COUPLING,
+  POLYLFO_SETTING_ATTENUATION,
+  POLYLFO_SETTING_OFFSET,
   POLYLFO_SETTING_FREQ_RANGE,
   POLYLFO_SETTING_FREQ_DIV_B,
   POLYLFO_SETTING_FREQ_DIV_C,
@@ -78,6 +80,14 @@ public:
 
   uint16_t get_coupling() const {
     return values_[POLYLFO_SETTING_COUPLING];
+  }
+
+  uint16_t get_attenuation() const {
+    return values_[POLYLFO_SETTING_ATTENUATION];
+  }
+
+  int16_t get_offset() const {
+    return values_[POLYLFO_SETTING_OFFSET];
   }
 
   frames::PolyLfoFreqDivisions get_freq_div_b() const {
@@ -155,6 +165,8 @@ SETTINGS_DECLARE(PolyLfo, POLYLFO_SETTING_LAST) {
   { 0, -128, 127, "Shape spread", NULL, settings::STORAGE_TYPE_I8 },
   { -1, -128, 127, "Phase/frq sprd", NULL, settings::STORAGE_TYPE_I8 },
   { 0, -128, 127, "Coupling", NULL, settings::STORAGE_TYPE_I8 },
+  { 230, 0, 230, "Attenuation", NULL, settings::STORAGE_TYPE_U8 },
+  { 0, -128, 127, "Offset", NULL, settings::STORAGE_TYPE_I8 },
   { 9, 0, 11, "Freq range", freq_range_names, settings::STORAGE_TYPE_U4 },
   { frames::POLYLFO_FREQ_DIV_NONE, frames::POLYLFO_FREQ_DIV_NONE, frames::POLYLFO_FREQ_DIV_LAST - 1, "B freq ratio", freq_div_names, settings::STORAGE_TYPE_U8 },
   { frames::POLYLFO_FREQ_DIV_NONE, frames::POLYLFO_FREQ_DIV_NONE, frames::POLYLFO_FREQ_DIV_LAST - 1, "C freq ratio", freq_div_names, settings::STORAGE_TYPE_U8 },
@@ -200,6 +212,9 @@ void FASTRUN POLYLFO_isr() {
   poly_lfo.lfo.set_coupling(USAT16(coupling));
 
   poly_lfo.lfo.set_shape_spread(SCALE8_16(poly_lfo.get_shape_spread() + 128));
+
+  poly_lfo.lfo.set_attenuation(SCALE8_16(poly_lfo.get_attenuation()));
+  poly_lfo.lfo.set_offset(SCALE8_16(poly_lfo.get_offset()));
 
   poly_lfo.lfo.set_freq_div_b(poly_lfo.get_freq_div_b());
   poly_lfo.lfo.set_freq_div_c(poly_lfo.get_freq_div_c());

--- a/software/o_c_REV/OC_debug.cpp
+++ b/software/o_c_REV/OC_debug.cpp
@@ -10,7 +10,7 @@
 
 extern void POLYLFO_debug();
 extern void BBGEN_debug();
-// extern void ENVGEN_debug();
+extern void ENVGEN_debug();
 extern void BYTEBEATGEN_debug();
 extern void H1200_debug();
 extern void QQ_debug();
@@ -100,7 +100,7 @@ static const DebugMenu debug_menus[] = {
   { " GFX", debug_menu_gfx },
   { " ADC", debug_menu_adc },
   { " POLYLFO", POLYLFO_debug },
-  // { " ENVGEN", ENVGEN_debug },
+  { " ENVGEN", ENVGEN_debug },
   { " BBGEN", BBGEN_debug },
   { " BYTEBEATGEN", BYTEBEATGEN_debug },
   { " H1200", H1200_debug },

--- a/software/o_c_REV/frames_poly_lfo.cpp
+++ b/software/o_c_REV/frames_poly_lfo.cpp
@@ -43,11 +43,13 @@ using namespace std;
 using namespace stmlib;
 
 void PolyLfo::Init() {
-  freq_range_ = 2;
+  freq_range_ = 9;
   spread_ = 0;
   shape_ = 0;
   shape_spread_ = 0;
   coupling_ = 0;
+  attenuation_ = 58880;
+  offset_ = 0 ;
   freq_div_b_ = freq_div_c_ = freq_div_d_ = POLYLFO_FREQ_DIV_NONE ;
   phase_reset_flag_ = false;
   std::fill(&value_[0], &value_[kNumChannels], 0);
@@ -189,6 +191,8 @@ void PolyLfo::Render(int32_t frequency, bool reset_phase) {
     } else {
       dac_code_[i] = wt_value_[i] + 32768; //Keyframer::ConvertToDacCode(value + 32768, 0);
     }
+    dac_code_[i] = ((dac_code_[i] * attenuation_) >> 16) + offset_ ;
+    // dac_code_[i] += offset_ ;
     wavetable_index += shape_spread_;
   }
 }

--- a/software/o_c_REV/frames_poly_lfo.h
+++ b/software/o_c_REV/frames_poly_lfo.h
@@ -127,6 +127,15 @@ class PolyLfo {
     
   }
 
+  inline void set_attenuation(uint16_t attenuation) {
+    attenuation_ = attenuation;
+    // attenuation_ = 65535;
+  }
+
+  inline void set_offset(int16_t offs) {
+    offset_ = offs;
+  }
+
   inline void set_freq_div_b(PolyLfoFreqDivisions div) {
     if (div != freq_div_b_) {
       freq_div_b_ = div;
@@ -180,6 +189,7 @@ class PolyLfo {
   inline const uint16_t dac_code(uint8_t index) const {
     return dac_code_[index];
   }
+
   static uint32_t FrequencyToPhaseIncrement(int32_t frequency, uint16_t frq_rng);
 
  private:
@@ -189,6 +199,8 @@ class PolyLfo {
   int16_t shape_spread_;
   int32_t spread_;
   int16_t coupling_;
+  int32_t attenuation_;
+  int32_t offset_;
   PolyLfoFreqDivisions freq_div_b_;
   PolyLfoFreqDivisions freq_div_c_;
   PolyLfoFreqDivisions freq_div_d_;

--- a/software/o_c_REV/peaks_multistage_envelope.cpp
+++ b/software/o_c_REV/peaks_multistage_envelope.cpp
@@ -42,7 +42,9 @@ void MultistageEnvelope::Init() {
   phase_increment_ = 0;
   start_value_ = 0;
   value_ = 0;
-  reset_behaviour_ = RESET_BEHAVIOUR_CARRY_ON;
+  attack_reset_behaviour_ = RESET_BEHAVIOUR_NULL;
+  decay_release_reset_behaviour_ = RESET_BEHAVIOUR_SEGMENT_PHASE;
+  reset_behaviour_ = RESET_BEHAVIOUR_NULL;
   attack_shape_ = ENV_SHAPE_QUARTIC;
   decay_shape_ = ENV_SHAPE_EXPONENTIAL;
   release_shape_ = ENV_SHAPE_EXPONENTIAL;
@@ -59,28 +61,28 @@ int16_t MultistageEnvelope::ProcessSingleSample(uint8_t control) {
       segment_ = 0;
       phase_ = 0 ;
     } else {
+      if (segment_ == 0) reset_behaviour_ = attack_reset_behaviour_ ;
+      else reset_behaviour_ = decay_release_reset_behaviour_;
       switch(reset_behaviour_) {
-        case RESET_BEHAVIOUR_LEVEL:
-          start_value_ = level_[0];
-          segment_ = 0 ;
+        case RESET_BEHAVIOUR_NULL:
           break ;
-        case RESET_BEHAVIOUR_SEGMENT:
+        case RESET_BEHAVIOUR_SEGMENT_PHASE:
+          segment_ = 0;
+          phase_ = 0;
           start_value_ = value_;
+          break ;
+        case RESET_BEHAVIOUR_SEGMENT_LEVEL_PHASE:
+          segment_ = 0;
+          phase_ = 0;
+          start_value_ = level_[0];
+          break ;
+        case RESET_BEHAVIOUR_SEGMENT_LEVEL:
+          start_value_ = level_[0];
           segment_ = 0 ;
           break ;
         case RESET_BEHAVIOUR_PHASE:
-          segment_ = 0;
-          phase_ = 0;
           start_value_ = value_;
-          break ;
-        case RESET_BEHAVIOUR_PHASE_AND_LEVEL:
-          segment_ = 0;
-          phase_ = 0;
-          start_value_ = level_[0];
-          break ;
-        case RESET_BEHAVIOUR_CARRY_ON:
-          // segment_ = 0;
-          // start_value_ = value_;
+          phase_ = 0 ;
           break ;
         default:
           break;              

--- a/software/o_c_REV/peaks_multistage_envelope.h
+++ b/software/o_c_REV/peaks_multistage_envelope.h
@@ -52,11 +52,11 @@ enum EnvelopeShape {
 };
 
 enum EnvResetBehaviour {
-  RESET_BEHAVIOUR_LEVEL,
+  RESET_BEHAVIOUR_NULL,
+  RESET_BEHAVIOUR_SEGMENT_PHASE,
+  RESET_BEHAVIOUR_SEGMENT_LEVEL_PHASE,
+  RESET_BEHAVIOUR_SEGMENT_LEVEL,
   RESET_BEHAVIOUR_PHASE,
-  RESET_BEHAVIOUR_SEGMENT,
-  RESET_BEHAVIOUR_PHASE_AND_LEVEL,
-  RESET_BEHAVIOUR_CARRY_ON,
   RESET_BEHAVIOUR_LAST
 };
 
@@ -357,8 +357,12 @@ class MultistageEnvelope {
     loop_end_ = 4;
   }
   
-  inline void set_reset_behaviour(EnvResetBehaviour reset_behaviour) {
-    reset_behaviour_ = reset_behaviour;
+  inline void set_attack_reset_behaviour(EnvResetBehaviour reset_behaviour) {
+    attack_reset_behaviour_ = reset_behaviour;
+  }
+
+  inline void set_decay_release_reset_behaviour(EnvResetBehaviour reset_behaviour) {
+    decay_release_reset_behaviour_ = reset_behaviour;
   }
 
   inline void reset() {
@@ -420,6 +424,8 @@ class MultistageEnvelope {
   uint16_t loop_start_;
   uint16_t loop_end_;
   
+  EnvResetBehaviour attack_reset_behaviour_;
+  EnvResetBehaviour decay_release_reset_behaviour_;
   EnvResetBehaviour reset_behaviour_;
   EnvelopeShape attack_shape_;
   EnvelopeShape decay_shape_;

--- a/software/o_c_REV/peaks_multistage_envelope.h
+++ b/software/o_c_REV/peaks_multistage_envelope.h
@@ -397,6 +397,23 @@ class MultistageEnvelope {
     release_multiplier_ = mult;
   }
 
+  inline void set_amplitude(uint16_t amp, bool sampled) {
+    amplitude_ = amp;
+    amplitude_sampled_ = sampled;
+  }
+
+  inline uint16_t get_amplitude_value() {
+    return(amplitude_) ;
+  }
+
+   inline uint16_t get_sampled_amplitude_value() {
+    return(sampled_amplitude_) ;
+  }
+
+   inline bool get_is_amplitude_sampled() {
+    return(amplitude_sampled_) ;
+  }
+
   // Render preview, normalized to kPreviewWidth pixels width
   // NOTE Lives dangerously and uses live values that might be updated by ISR
   uint16_t RenderPreview(int16_t *values, uint16_t *segment_start_points, uint16_t *loop_points, uint16_t &current_phase) const;
@@ -434,8 +451,11 @@ class MultistageEnvelope {
   uint16_t attack_multiplier_;
   uint16_t decay_multiplier_;
   uint16_t release_multiplier_;
+  uint16_t amplitude_;
+  bool amplitude_sampled_ ;
+  uint16_t sampled_amplitude_;
+  uint32_t scaled_value_ ;
 
-  
   DISALLOW_COPY_AND_ASSIGN(MultistageEnvelope);
 };
 

--- a/software/o_c_REV/peaks_multistage_envelope.h
+++ b/software/o_c_REV/peaks_multistage_envelope.h
@@ -51,6 +51,15 @@ enum EnvelopeShape {
   ENV_SHAPE_LAST
 };
 
+enum EnvResetBehaviour {
+  RESET_BEHAVIOUR_LEVEL,
+  RESET_BEHAVIOUR_PHASE,
+  RESET_BEHAVIOUR_SEGMENT,
+  RESET_BEHAVIOUR_PHASE_AND_LEVEL,
+  RESET_BEHAVIOUR_CARRY_ON,
+  RESET_BEHAVIOUR_LAST
+};
+
 const uint16_t kMaxNumSegments = 8;
 const uint32_t kPreviewWidth = 128;
 const uint32_t kFastPreviewWidth = 64;
@@ -348,8 +357,8 @@ class MultistageEnvelope {
     loop_end_ = 4;
   }
   
-  inline void set_hard_reset(bool hard_reset) {
-    hard_reset_ = hard_reset;
+  inline void set_reset_behaviour(EnvResetBehaviour reset_behaviour) {
+    reset_behaviour_ = reset_behaviour;
   }
 
   inline void reset() {
@@ -411,7 +420,7 @@ class MultistageEnvelope {
   uint16_t loop_start_;
   uint16_t loop_end_;
   
-  bool hard_reset_;
+  EnvResetBehaviour reset_behaviour_;
   EnvelopeShape attack_shape_;
   EnvelopeShape decay_shape_;
   EnvelopeShape release_shape_;


### PR DESCRIPTION
All changes tested (to some degree) and documented in the v1.2.1 documentation on the wiki, but with one bug: on saving settings, the frequency range for POLYLFO defaults back to the slowest setting (cosmological). Probably some  obvious, stupid mistake, but I can't spot it...