### PR TITLE
Harrington qq tweaks

### DIFF
--- a/software/o_c_REV/APP_H1200.ino
+++ b/software/o_c_REV/APP_H1200.ino
@@ -1045,11 +1045,11 @@ void H1200_handleButtonEvent(const UI::Event &event) {
   if (UI::EVENT_BUTTON_PRESS == event.type) {
     switch (event.control) {
       case OC::CONTROL_BUTTON_UP:
-        if (h1200_settings.change_value(H1200_SETTING_INVERSION, 1))
+        if (h1200_settings.change_value(H1200_SETTING_OCTAVE, 1))
           h1200_state.force_update();
         break;
       case OC::CONTROL_BUTTON_DOWN:
-        if (h1200_settings.change_value(H1200_SETTING_INVERSION, -1))
+        if (h1200_settings.change_value(H1200_SETTING_OCTAVE, -1))
           h1200_state.force_update();
         break;
       case OC::CONTROL_BUTTON_L:
@@ -1070,7 +1070,7 @@ void H1200_handleButtonEvent(const UI::Event &event) {
 void H1200_handleEncoderEvent(const UI::Event &event) {
 
   if (OC::CONTROL_ENCODER_L == event.control) {
-    if (h1200_settings.change_value(H1200_SETTING_ROOT_OFFSET, event.value))
+    if (h1200_settings.change_value(H1200_SETTING_INVERSION, event.value))
       h1200_state.force_update();
   } else if (OC::CONTROL_ENCODER_R == event.control) {
     if (h1200_state.cursor.editing()) {

--- a/software/o_c_REV/APP_QQ.ino
+++ b/software/o_c_REV/APP_QQ.ino
@@ -992,6 +992,7 @@ public:
       *settings++ = CHANNEL_SETTING_CLKDIV;
       *settings++ = CHANNEL_SETTING_DELAY;
     }
+    *settings++ = CHANNEL_SETTING_OCTAVE;
     *settings++ = CHANNEL_SETTING_TRANSPOSE;
     *settings++ = CHANNEL_SETTING_FINE;
   


### PR DESCRIPTION
Changed default behaviour of L Encoder and buttons in Harrington app:
- L Encoder changes inversion
- Up/Down buttons change octaves

Made octave option visible in Quantermain app UI. 
- I realise that the up/down buttons change octave per channel but I felt it was clearer (and possibly more consistent) by also adding it as a menu item in this app