### PR TITLE
Trigger long-press as soon as the button is held long enough, instead…

### DIFF
--- a/software/o_c_REV/OC_ui.cpp
+++ b/software/o_c_REV/OC_ui.cpp
@@ -79,11 +79,15 @@ void FASTRUN Ui::Poll() {
     auto &button = buttons_[i];
     if (button.just_pressed()) {
       button_press_time_[i] = now;
-    } else if (button.released()) {
-      if (now - button_press_time_[i] < kLongPressTicks)
-        PushEvent(UI::EVENT_BUTTON_PRESS, control_mask(i), 0, button_state);
-      else
+    } else if (button.pressed()) {
+      if (now - button_press_time_[i] == kLongPressTicks)
+      {
+        button_state &= ~control_mask(i);
         PushEvent(UI::EVENT_BUTTON_LONG_PRESS, control_mask(i), 0, button_state);
+      }
+    } else if (button.released()) {
+      if (now - button_press_time_[i] < kLongPressTicks + 7)
+        PushEvent(UI::EVENT_BUTTON_PRESS, control_mask(i), 0, button_state);
     }
   }
 


### PR DESCRIPTION
… of at release

Hopefully this doesn't have any side effects I haven't thought of. I don't know the codebase well enough to say for sure.

Line 85 is to stop the button being flagged to ignore by Ui::AppSettings(). Kinda hacky.

The +7 in line 89 is compensation for the 7-bit button debouncing.