### PR TITLE
add quick save option via screensaver shortcut

### DIFF
--- a/software/o_c_REV/OC_apps.ino
+++ b/software/o_c_REV/OC_apps.ino
@@ -350,6 +350,15 @@ void draw_save_message(uint8_t c) {
   GRAPHICS_END_FRAME();
 }
 
+void Ui::SaveSettings() {
+  save_global_settings();
+  save_app_data();
+  // draw message:
+  int cnt = 0;
+  while(idle_time() < SETTINGS_SAVE_TIMEOUT_MS)
+    draw_save_message((cnt++) >> 4);
+}
+
 void Ui::AppSettings() {
 
   SetButtonIgnoreMask();

--- a/software/o_c_REV/OC_options.h
+++ b/software/o_c_REV/OC_options.h
@@ -30,7 +30,8 @@
 //#define DAC8564
 /* ------------ 0 / 10V range ---------------------------------------------------------------------------------------------------------------------------  */
 //#define IO_10V
-
+/* ------------ uncomment for all settings to get saved whenever the user invokes the screensaver shortcut ----------------------------------------------  */
+// #define screensaver_quick_save
 
 /* do not edit the stuff below (unless ... ) */
 

--- a/software/o_c_REV/OC_ui.h
+++ b/software/o_c_REV/OC_ui.h
@@ -42,6 +42,7 @@ enum UiMode {
   UI_MODE_SCREENSAVER,
   UI_MODE_MENU,
   UI_MODE_APP_SETTINGS,
+  UI_MODE_SAVE_SETTINGS,
   UI_MODE_CALIBRATE
 };
 
@@ -59,6 +60,7 @@ public:
   void DebugStats();
   void Calibrate();
   void AppSettings();
+  void SaveSettings();
   UiMode DispatchEvents(OC::App *app);
 
   void Poll();

--- a/software/o_c_REV/o_c_REV.ino
+++ b/software/o_c_REV/o_c_REV.ino
@@ -190,8 +190,12 @@ void FASTRUN loop() {
 
     // State transition for app
     if (mode != ui_mode) {
-      if (OC::UI_MODE_SCREENSAVER == mode)
+      if (OC::UI_MODE_SCREENSAVER == mode) {
+        #ifdef screensaver_quick_save
+          OC::ui.SaveSettings();
+        #endif
         OC::apps::current_app->HandleAppEvent(OC::APP_EVENT_SCREENSAVER_ON);
+      }
       else if (OC::UI_MODE_SCREENSAVER == ui_mode)
         OC::apps::current_app->HandleAppEvent(OC::APP_EVENT_SCREENSAVER_OFF);
       ui_mode = mode;


### PR DESCRIPTION
Adds a new default behavior that is enabled by uncommenting https://github.com/warrenwinter/O_C/blob/5ff81313f65ddda4f3e749f53976a76de1d004b9/software/o_c_REV/OC_options.h#L34 : the module will then save all settings (identical to how it is done from the app selection menu) every time the user manually switches to the screensaver (using a given app's screensaver shortcut, e.g., long-press of the up-button in Quantermain).

Offered for those (maybe just me) who wish to save settings with one action, and don't mind the semantic conflation of switching to screensaver with saving settings.